### PR TITLE
Pay Core Function - move the callback broadcasting call 

### DIFF
--- a/src/core/pay.ts
+++ b/src/core/pay.ts
@@ -203,8 +203,6 @@ export const pay = async (
     providerSigner,
   );
 
-  callbacks && callbacks.broadcasting && callbacks.broadcasting();
-
   // solidity doesn't work with decimal points
   const marketplaceFeeValue = 100 * marketplaceFee;
   const arbitratorFeeValue = 100 * arbitratorFee;
@@ -236,6 +234,8 @@ export const pay = async (
   };
 
   try {
+    callbacks && callbacks.broadcasting && callbacks.broadcasting();
+
     let payTx: any;
 
     const isETH = tokenAddress === ETH_ADDRESS;


### PR DESCRIPTION
Move the callback broadcasting call close to the pay function, which makes more sense, close to the broadcasting tx.