### PR TITLE
[UN-1583] fix getSingleBalance always returns "Ready for claim"

### DIFF
--- a/src/core/getSingleBalance.ts
+++ b/src/core/getSingleBalance.ts
@@ -28,13 +28,12 @@ export const getSingleBalance = async (
       symbol: escrowData.token.symbol,
       decimals: escrowData.token.decimals,
     },
-    status: "Ready to claim",
+    status: escrowData.status,
     amount: amountBN.toString(),
     amountBN: displayableAmountBN(amountBN, escrowData.token.decimals),
     displayableAmount: displayableAmount(amountBN, escrowData.token.decimals),
     connectedUser: escrowData.connectedUser,
     walletAddress: escrowData.walletAddress,
-    statusEscrow: escrowData.status,
   };
 
   return balance;

--- a/src/typing/index.ts
+++ b/src/typing/index.ts
@@ -884,9 +884,6 @@ export interface IBalanceDetailed extends IBalance {
 
   /** Address of the connected user */
   walletAddress: string;
-
-  /** Indicates status of the payment (claimed, latestChallengeBy, latestSettlementBy and its escrow state like 'Paid' | 'Unpaid' etc.) */
-  status: IEscrowStatus;
 }
 
 /**

--- a/src/typing/index.ts
+++ b/src/typing/index.ts
@@ -66,10 +66,19 @@ export enum EscrowStatus {
 export type tEscrowParty = "buyer" | "seller" | null;
 
 /**
- * Full status of an escrow.
+ * Full status of a payment
+ *
+ * @example // A returned object might look e.g. like this:
+ * {
+ *    state: "Paid",
+ *    latestChallengeBy: null,
+ *    latestSettlementOfferBy: null,
+ *    claimed: false
+ * },
+ *
  */
 export interface IEscrowStatus {
-  /** The current state of an escrow (PAID | UNPAID | RELEASED | PERIOD_EXPIRED | REFUNDED | CHALLENGED | SETTLED). */
+  /** The current state of an escrow ('Paid' | 'Unpaid' | 'Released' | 'Period Expired' | 'Refunded' | 'Challenged' | 'Settled'). */
   state: EscrowStatus;
   /** True if the payment was already withdrawn from the escrow */
   claimed: boolean;
@@ -80,7 +89,7 @@ export interface IEscrowStatus {
 }
 
 /**
- * Detailed information about the escrow
+ * Full information about the escrow
  *
  * @example // A returned object might look e.g. like this:
  * {
@@ -121,9 +130,11 @@ export interface IEscrowStatus {
 export interface IEscrowData {
   /** Amount in token's (or ETH's) wei unit */
   amount: BigNumberJs; // ERC20 | Ether
+
+  /** ID of the escrow that the transaction created or acted upon */
   escrowId: number;
 
-  /** See the interface for more details */
+  /** Indicates status of the payment (claimed, latestChallengeBy, latestSettlementBy and its escrow state like 'Paid' | 'Unpaid' etc.) */
   status: IEscrowStatus;
 
   /** Marketplace address */
@@ -562,7 +573,7 @@ export interface IGenericTransactionCallbacks {
 export interface IPayTransactionPayload {
   transactionHash: string;
 
-  /** Name of the event ("Pay") */
+  /** Name of the event ('Pay') */
   name?: string;
 
   /** Number of the block in which the payment transaction was minted */
@@ -854,8 +865,8 @@ export interface IBalance {
   /** Information about the token */
   token?: IToken;
 
-  /** Whether the balance is still waiting for the challenge period to end, or is ready to claim */
-  status: "Pending" | "Ready to claim";
+  /** Indicates status of the payment (claimed, latestChallengeBy, latestSettlementBy and its escrow state like 'Paid' | 'Unpaid' etc.) */
+  status: IEscrowStatus;
 }
 
 /**
@@ -874,8 +885,8 @@ export interface IBalanceDetailed extends IBalance {
   /** Address of the connected user */
   walletAddress: string;
 
-  /** Indicates status of the payment (PAID | UNPAID | RELEASED | PERIOD_EXPIRED | REFUNDED | CHALLENGED | SETTLED) */
-  statusEscrow: IEscrowStatus;
+  /** Indicates status of the payment (claimed, latestChallengeBy, latestSettlementBy and its escrow state like 'Paid' | 'Unpaid' etc.) */
+  status: IEscrowStatus;
 }
 
 /**
@@ -891,7 +902,12 @@ export interface IBalanceDetailed extends IBalance {
  *           symbol: "ETH",
  *           decimals: 18
  *        },
- *        status: "Pending",
+ *        status: {
+ *           state: "Paid",
+ *           latestChallengeBy: null,
+ *           latestSettlementOfferBy: null,
+ *           claimed: false
+ *        },
  *        amount: "1586200000000000000",
  *        total: "1586200000000000000",
  *        displayableAmount: "1.5862",
@@ -905,7 +921,12 @@ export interface IBalanceDetailed extends IBalance {
  *           symbol: "USDC",
  *           decimals: 6
  *        },
- *        status: "Ready to claim",
+ *        status: {
+ *           state: "Period Expired",
+ *           latestChallengeBy: null,
+ *           latestSettlementOfferBy: null,
+ *           claimed: false
+ *        },
  *        amount: "1786200000",
  *        total: "1786200000",
  *        displayableAmount: "1786.2",
@@ -917,7 +938,12 @@ export interface IBalanceDetailed extends IBalance {
  *           symbol: "USDT",
  *           decimals: 6
  *        },
- *        status: "Ready to claim",
+ *        status: {
+ *           state: "Period Expired",
+ *           latestChallengeBy: null,
+ *           latestSettlementOfferBy: null,
+ *           claimed: false
+ *        },
  *        amount: "2379300000",
  *        total: "2379300000",
  *        displayableAmount: "2379.3",
@@ -1013,7 +1039,7 @@ export interface IndexerInstance {
    *    challengePeriodStart: "2023-01-24T11:54:33.000Z",
    *    challengePeriodEnd: "2023-02-07T11:54:33.000Z",
    *    status: {
-   *       state: "Paid",
+   *       state: "Period Expired",
    *       latestChallengeBy: null,
    *       latestSettlementOfferBy: null,
    *       claimed: false
@@ -1059,7 +1085,12 @@ export interface IndexerInstance {
    *           symbol: "ETH",
    *           decimals: 18
    *        },
-   *        status: "Pending",
+   *        status: {
+   *           state: "Period Expired",
+   *           latestChallengeBy: null,
+   *           latestSettlementOfferBy: null,
+   *           claimed: false
+   *        },
    *        amount: "1586200000000000000",
    *        total: "1586200000000000000",
    *        displayableAmount: "1.5862",
@@ -1073,7 +1104,12 @@ export interface IndexerInstance {
    *           symbol: "USDC",
    *           decimals: 6
    *        },
-   *        status: "Ready to claim",
+   *        status: {
+   *           state: "Period Expired",
+   *           latestChallengeBy: null,
+   *           latestSettlementOfferBy: null,
+   *           claimed: false
+   *        },
    *        amount: "1786200000",
    *        total: "1786200000",
    *        displayableAmount: "1786.2",
@@ -1085,7 +1121,12 @@ export interface IndexerInstance {
    *           symbol: "USDT",
    *           decimals: 6
    *        },
-   *        status: "Ready to claim",
+   *        status: {
+   *           state: "Period Expired",
+   *           latestChallengeBy: null,
+   *           latestSettlementOfferBy: null,
+   *           claimed: false
+   *        },
    *        amount: "2379300000",
    *        total: "2379300000",
    *        displayableAmount: "2379.3",
@@ -1171,6 +1212,7 @@ export interface IGetEscrowData extends Omit<IEscrowData, "tokenAddress"> {
 }
 
 export interface ISettlementOfferModalProps {
+  /** ID of the escrow that the transaction created or acted upon */
   escrowId: number;
   escrowData?: IGetEscrowData;
   deferredPromise: Deferred<any>;
@@ -1178,12 +1220,14 @@ export interface ISettlementOfferModalProps {
 }
 
 export interface ISettlementApproveModalProps {
+  /** ID of the escrow that the transaction created or acted upon */
   escrowId: number;
   escrowData?: IGetEscrowData;
   deferredPromise: Deferred<any>;
   callbacks?: ISettlementApproveTransactionCallbacks;
 }
 export interface IArbitrateModalProps {
+  /** ID of the escrow that the transaction created or acted upon */
   escrowId: number;
   deferredPromise: Deferred<any>;
   callbacks?: IArbitrationTransactionCallbacks;

--- a/src/ui/internal/modals/Claim.tsx
+++ b/src/ui/internal/modals/Claim.tsx
@@ -74,23 +74,24 @@ export function ClaimModal(props: IClaimModalProps) {
 
         setEscrowBalance(_escrowBalance);
 
-        setModalAction({
-          isForbidden: true,
-        });
-
         if (_escrowBalance.connectedUser === "other") {
           setModalAction({
-            isForbidden: false,
+            isForbidden: true,
           });
         }
 
-        if (
-          _escrowBalance.status.claimed ||
-          _escrowBalance.status.state !== EscrowStatus.PERIOD_EXPIRED
-        ) {
+        if (_escrowBalance.status.state !== EscrowStatus.PERIOD_EXPIRED) {
           setModalAction({
-            isForbidden: false,
-            reason: "You cannot claim this payment at this time",
+            isForbidden: true,
+            reason:
+              "The escrow has been challenged and its period has not expired yet",
+          });
+        }
+
+        if (_escrowBalance.status.claimed) {
+          setModalAction({
+            isForbidden: true,
+            reason: "This escrow has already been claimed",
           });
         }
       } catch (error: any) {
@@ -193,7 +194,7 @@ export function ClaimModal(props: IClaimModalProps) {
     if (!escrowBalance) {
       return <ModalBodySkeleton />;
     }
-    if (!(isLoading || modalAction.isForbidden)) {
+    if (!(isLoading || !modalAction.isForbidden)) {
       return (
         <Forbidden onClose={onModalClose} description={modalAction.reason} />
       );
@@ -213,7 +214,7 @@ export function ClaimModal(props: IClaimModalProps) {
   };
 
   const ModalFooter = () => {
-    if (!(escrowBalance && (isLoading || modalAction.isForbidden))) {
+    if (!(escrowBalance && (isLoading || !modalAction.isForbidden))) {
       return null;
     }
 

--- a/src/ui/internal/modals/Claim.tsx
+++ b/src/ui/internal/modals/Claim.tsx
@@ -85,8 +85,8 @@ export function ClaimModal(props: IClaimModalProps) {
         }
 
         if (
-          _escrowBalance.statusEscrow.claimed ||
-          _escrowBalance.statusEscrow.state !== EscrowStatus.PERIOD_EXPIRED
+          _escrowBalance.status.claimed ||
+          _escrowBalance.status.state !== EscrowStatus.PERIOD_EXPIRED
         ) {
           setModalAction({
             isForbidden: false,
@@ -114,7 +114,9 @@ export function ClaimModal(props: IClaimModalProps) {
       if (isLoading || !escrowBalance) {
         return (
           <tr>
-            <Skeleton width="100%" height={25} />
+            <td>
+              <Skeleton width="100%" height={25} />
+            </td>
           </tr>
         );
       }


### PR DESCRIPTION
bonus:
- [x] refactored the examples (to match with the new status changes)
- [x] changed apostrophes from `"` to `'` to just use `'` everywhere
- [x] fixed the description of IEscrowStatus (what you get back is not an enum, hence `PAID => 'Paid'` etc.)
- [x] fixed an issue that we had in the console (something like error when validating the DOM: a span can never be a child of a tr)