### PR TITLE
Ext payment

### DIFF
--- a/src/config/marker.ts
+++ b/src/config/marker.ts
@@ -14,4 +14,5 @@ export const MARKER = {
   challengePeriod: "How long will it be possible to challenge the payment",
   challengePeriodExtension:
     "How long will a new challenge period last after a challenge",
+  reference: "A reference for the payment",
 };

--- a/src/indexer/internal/payload.ts
+++ b/src/indexer/internal/payload.ts
@@ -42,4 +42,6 @@ export const returningValues = [
   "amount_protocol",
   "amount_arbitrator",
   "amount_marketplace",
+  "reference",
+  "status",
 ];

--- a/src/typing/index.ts
+++ b/src/typing/index.ts
@@ -39,7 +39,9 @@ export interface IPaymentProps {
   arbitratorFee?: number;
   /** By how much will the challenge period get extended after a challenge (in seconds) */
   challengePeriodExtension?: number;
-  /** A url to redirect to, when the payment is done (or canceled) */
+  /** (UI only) A reference for the payment to display */
+  reference?: string;
+  /** (UI only) A url to redirect to, when the payment is done or canceled */
   callbackUrl?: string;
 }
 

--- a/src/typing/index.ts
+++ b/src/typing/index.ts
@@ -39,6 +39,8 @@ export interface IPaymentProps {
   arbitratorFee?: number;
   /** By how much will the challenge period get extended after a challenge (in seconds) */
   challengePeriodExtension?: number;
+  /** A url to redirect to, when the payment is done (or canceled) */
+  callbackUrl?: string;
 }
 
 export interface IValidateProps extends IPaymentProps {

--- a/src/ui/internal/components/ScopedModal.tsx
+++ b/src/ui/internal/components/ScopedModal.tsx
@@ -19,6 +19,7 @@ interface ScopedModalProps {
   footer: ReactNode;
   isLoading: boolean;
   loadingMessage: string;
+  closeable?: boolean;
   onClose?: () => any;
   modalAction?: any;
 }
@@ -78,9 +79,13 @@ export const ScopedModal: React.FunctionComponent<ScopedModalProps> = (
     <Modal isLoading={props.isLoading} loadingMessage={props.loadingMessage}>
       <ModalHeader>
         <ModalHeaderTitle>{props.title}</ModalHeaderTitle>
-        <ModalHeaderClose onClick={props.onClose}>
-          <CloseIcon />
-        </ModalHeaderClose>
+        {props.closeable ? (
+          <ModalHeaderClose onClick={props.onClose}>
+            <CloseIcon />
+          </ModalHeaderClose>
+        ) : (
+          <></>
+        )}
       </ModalHeader>
       <BodyWithFooter />
     </Modal>

--- a/src/ui/internal/modals/Pay.tsx
+++ b/src/ui/internal/modals/Pay.tsx
@@ -182,19 +182,16 @@ export function PayModal(props: IPaymentModalProps) {
               />
             </>
           )}
-          {props.paymentProps.marketplace &&
-            props.paymentProps.marketplace?.toLowerCase() !==
-              ADDRESS_ZERO.toLowerCase() && (
-              <DataDisplayer
-                label="Marketplace Address"
-                value={reduceAddress(
-                  props.paymentProps.marketplace,
-                  props.paymentProps.ensAddresses?.marketplace,
-                )}
-                copy={props.paymentProps.marketplace}
-                marker={MARKER.marketplace}
-              />
-            )}
+          {props.paymentProps.reference ? (
+            <DataDisplayer
+              label="Reference"
+              value={props.paymentProps.reference}
+              copy={props.paymentProps.reference}
+              marker={MARKER.reference}
+            />
+          ) : (
+            <></>
+          )}
         </ContainerDataDisplayer>
       </>
     );

--- a/src/ui/internal/modals/Pay.tsx
+++ b/src/ui/internal/modals/Pay.tsx
@@ -209,7 +209,7 @@ export function PayModal(props: IPaymentModalProps) {
       buttonCallback = (
         <Button
           fullWidth
-          variant="secondary"
+          variant="tertiary"
           style={{ marginTop: 15 }}
           disabled={isLoadingAnything}
           onClick={() =>

--- a/src/ui/internal/modals/Pay.tsx
+++ b/src/ui/internal/modals/Pay.tsx
@@ -52,7 +52,9 @@ export function PayModal(props: IPaymentModalProps) {
     error: errorToken,
   } = useTokenInfo(props.paymentProps.tokenAddress);
 
-  const closeHandlerRef = useModalCloseHandler(onModalClose);
+  const closeHandlerRef = useModalCloseHandler(
+    props.paymentProps?.callbackUrl ? () => {} : onModalClose,
+  );
   const [modalTitle, setModalTitle] = React.useState("Payment");
   const [paymentStatus, setPaymentStatus] = React.useState<EscrowStatus>(
     EscrowStatus.UNPAID,
@@ -201,6 +203,23 @@ export function PayModal(props: IPaymentModalProps) {
   const ModalFooter = () => {
     let buttonChildren;
     let buttonOnClick;
+    let buttonCallback = <></>;
+
+    if (props.paymentProps?.callbackUrl) {
+      buttonCallback = (
+        <Button
+          fullWidth
+          variant="secondary"
+          style={{ marginTop: 15 }}
+          disabled={isLoadingAnything}
+          onClick={() =>
+            (window.location.href = props.paymentProps.callbackUrl)
+          }
+        >
+          Cancel
+        </Button>
+      );
+    }
 
     if (!(error || success)) {
       buttonChildren = `Pay ${props.paymentProps.amount} ${
@@ -209,16 +228,25 @@ export function PayModal(props: IPaymentModalProps) {
       buttonOnClick = onPayClick;
     } else if (success) {
       buttonChildren = "Close";
-      buttonOnClick = onModalClose;
+      if (props.paymentProps?.callbackUrl) {
+        buttonCallback = <></>;
+        buttonOnClick = () =>
+          (window.location.href = props.paymentProps.callbackUrl);
+      } else {
+        buttonOnClick = onModalClose;
+      }
     } else {
       buttonChildren = "Retry";
       buttonOnClick = onPayClick;
     }
 
     return (
-      <Button fullWidth disabled={isLoadingAnything} onClick={buttonOnClick}>
-        {buttonChildren}
-      </Button>
+      <>
+        <Button fullWidth disabled={isLoadingAnything} onClick={buttonOnClick}>
+          {buttonChildren}
+        </Button>
+        {buttonCallback}
+      </>
     );
   };
 
@@ -228,6 +256,7 @@ export function PayModal(props: IPaymentModalProps) {
         title={modalTitle}
         body={<ModalBody />}
         footer={<ModalFooter />}
+        closeable={props.paymentProps?.callbackUrl ? false : true}
         onClose={onModalClose}
         isLoading={isLoadingAnything}
         loadingMessage={loadingMessage}


### PR DESCRIPTION
Adds two optional parameters to the pay function (only affecting UI): a reference for the payment to display, and a callback url to redirect to when the payment is done or canceled. Useful for external integrations.
  